### PR TITLE
fix(mobile): correct lot numbering and animate history drawer

### DIFF
--- a/frontend/src/component/PortfolioTable.jsx
+++ b/frontend/src/component/PortfolioTable.jsx
@@ -140,14 +140,12 @@ export default function PortfolioTable({
 				onViewHistory={handleViewHistory}
 				onDelete={handleDeleteStock}
 			/>
-			{selectedStock && (
-				<StockHistoryModal
-					open={!!selectedStock}
-					onClose={handleCloseHistoryModal}
-					stockName={selectedStock.stockName}
-					history={selectedStock.history}
-				/>
-			)}
+			<StockHistoryModal
+				open={!!selectedStock}
+				onClose={handleCloseHistoryModal}
+				stockName={selectedStock?.stockName ?? ""}
+				history={selectedStock?.history ?? []}
+			/>
 			{deleteModalOpen && stockToDelete && (
 				<DeleteStockModal
 					open={deleteModalOpen}

--- a/frontend/src/component/StockHistoryModal.jsx
+++ b/frontend/src/component/StockHistoryModal.jsx
@@ -453,7 +453,7 @@ export default function StockHistoryModal({ open, onClose, stockName, history })
 							</Typography>
 						</Box>
 					) : (
-						sortedHistory.map((lot, i) => (
+						[...sortedHistory].reverse().map((lot, i) => (
 							<Box key={lot._id}>
 								<LotCard lot={lot} index={i} />
 								{i < sortedHistory.length - 1 && <Divider />}


### PR DESCRIPTION
- Reverse lot display order so oldest purchase = Lot 1 (FIFO order)
- Always mount StockHistoryModal so SwipeableDrawer can animate open
- Add Cost label to buy row, fix Total Sold to include total cost
- Safe area padding and bottom breathing room on history drawer