### PR TITLE
feat(ui): FAB for mobile add stock, first name heading, divider, smal…

### DIFF
--- a/frontend/src/component/PortfolioHeader.jsx
+++ b/frontend/src/component/PortfolioHeader.jsx
@@ -3,11 +3,11 @@ import {
 	Box,
 	Typography,
 	Button,
-	IconButton,
 	Tabs,
 	Tab,
 	TextField,
 	InputAdornment,
+	Divider,
 } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import SearchIcon from "@mui/icons-material/Search";
@@ -18,6 +18,7 @@ export default function PortfolioHeader({
 	tab,
 	onTabChange,
 	onAddStock,
+	username,
 	children,
 }) {
 	return (
@@ -29,7 +30,7 @@ export default function PortfolioHeader({
 					alignItems: "center",
 					justifyContent: "space-between",
 					gap: 1,
-					mb: 2,
+					mb: 1.5,
 					minHeight: { xs: 44, sm: "auto" },
 				}}
 			>
@@ -37,27 +38,12 @@ export default function PortfolioHeader({
 					variant="h4"
 					fontWeight="bold"
 					sx={{
-						fontSize: { xs: "1.5rem", sm: "2.125rem" },
+						fontSize: { xs: "1.2rem", sm: "1.6rem" },
 						lineHeight: 1.15,
 					}}
 				>
-					My Portfolio
+					{username ? `${username}'s Portfolio` : "My Portfolio"}
 				</Typography>
-				<IconButton
-					aria-label="add stock"
-					onClick={onAddStock}
-					sx={{
-						display: { xs: "inline-flex", sm: "none" },
-						width: 44,
-						height: 44,
-						borderRadius: 1.5,
-						backgroundColor: "primary.main",
-						color: "primary.contrastText",
-						"&:hover": { backgroundColor: "primary.dark" },
-					}}
-				>
-					<AddIcon />
-				</IconButton>
 				<Button
 					variant="contained"
 					color="primary"
@@ -65,15 +51,17 @@ export default function PortfolioHeader({
 					startIcon={<AddIcon />}
 					sx={{
 						display: { xs: "none", sm: "inline-flex" },
-						px: 3,
-						py: 1,
-						fontSize: "1rem",
+						px: 2,
+						py: 0.6,
+						fontSize: "0.875rem",
 						whiteSpace: "nowrap",
 					}}
 				>
 					Add Stock
 				</Button>
 			</Box>
+
+			<Divider sx={{ mb: 2 }} />
 
 			{children}
 

--- a/frontend/src/pages/DashboardPage.jsx
+++ b/frontend/src/pages/DashboardPage.jsx
@@ -5,7 +5,8 @@ import PortfolioTable from "../component/PortfolioTable";
 import PortfolioHeader from "../component/PortfolioHeader";
 import PortfolioSummary from "../component/PortfolioSummary";
 import useMarketData from "../hooks/useMarketData";
-import { Box, Typography, CircularProgress } from "@mui/material";
+import { Box, Typography, CircularProgress, Fab, useTheme, useMediaQuery, useScrollTrigger } from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
 
 export default function DashboardPage() {
 	const user = useSelector((s) => s.auth.user);
@@ -17,6 +18,9 @@ export default function DashboardPage() {
 	const deferredSearch = useDeferredValue(search);
 	const [addOpen, setAddOpen] = useState(false);
 	const { ltpMap, isConnected } = useMarketData();
+	const theme = useTheme();
+	const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+	const scrolled = useScrollTrigger({ disableHysteresis: true, threshold: 60 });
 
 	useEffect(() => {
 		if (!isAuthLoading && !user) {
@@ -78,6 +82,7 @@ export default function DashboardPage() {
 				tab={tab}
 				onTabChange={setTab}
 				onAddStock={handleAddStock}
+				username={user?.name?.split(" ")[0]}
 			>
 				<PortfolioSummary ltpMap={ltpMap} />
 			</PortfolioHeader>
@@ -89,6 +94,54 @@ export default function DashboardPage() {
 				ltpMap={ltpMap}
 				isConnected={isConnected}
 			/>
+
+			{isMobile && (
+				<Fab
+					color="primary"
+					aria-label="add stock"
+					onClick={handleAddStock}
+					variant="extended"
+					sx={{
+						position: "fixed",
+						bottom: 24,
+						right: 20,
+						boxShadow: 6,
+						fontWeight: 700,
+						fontSize: "0.875rem",
+						zIndex: 1200,
+						minWidth: "unset",
+						width: scrolled ? 56 : "auto",
+						height: 56,
+						borderRadius: scrolled ? "50%" : "28px",
+						px: scrolled ? 0 : 2,
+						transition: [
+							"width 0.4s cubic-bezier(0.4,0,0.2,1)",
+							"border-radius 0.4s cubic-bezier(0.4,0,0.2,1)",
+							"padding 0.4s cubic-bezier(0.4,0,0.2,1)",
+						].join(", "),
+						overflow: "hidden",
+					}}
+				>
+					<AddIcon sx={{ fontSize: "1.1rem", flexShrink: 0 }} />
+					<Box
+						component="span"
+						sx={{
+							maxWidth: scrolled ? 0 : 100,
+							opacity: scrolled ? 0 : 1,
+							overflow: "hidden",
+							whiteSpace: "nowrap",
+							ml: scrolled ? 0 : 0.75,
+							transition: [
+								"max-width 0.4s cubic-bezier(0.4,0,0.2,1)",
+								"opacity 0.25s ease",
+								"margin 0.4s cubic-bezier(0.4,0,0.2,1)",
+							].join(", "),
+						}}
+					>
+						Add Stock
+					</Box>
+				</Fab>
+			)}
 		</Box>
 	);
 }


### PR DESCRIPTION
…ler desktop button

- Replace mobile header + icon with animated FAB (extends to pill at top, collapses to circle on scroll via useScrollTrigger)
- Show first name only in portfolio heading (Sundram's Portfolio)
- Add Divider below heading row for visual separation
- Reduce desktop Add Stock button size (px:2 py:0.6 0.875rem)